### PR TITLE
Add support for adding attachment to sage

### DIFF
--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -15,6 +15,7 @@ module IntacctRuby
       delete
       create_invoice
       update_invoice
+      create_supdoc
     ).freeze
 
     CU_TYPES = %w(create update).freeze


### PR DESCRIPTION
Add `create_supdoc` function to allowed types to support
creating attachments in sage.